### PR TITLE
ITI.Bottle.Tests csproj now launch NUnit as a start action

### DIFF
--- a/FirstSolution/Tests/ITI.Bottle.Tests/ITI.Bottle.Tests.csproj
+++ b/FirstSolution/Tests/ITI.Bottle.Tests/ITI.Bottle.Tests.csproj
@@ -20,6 +20,9 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <StartAction>Program</StartAction>
+    <StartProgram>$(SolutionDir)packages\NUnit.Runners.2.6.4\tools\nunit.exe</StartProgram>
+    <StartArguments>ITI.Bottle.Tests.dll</StartArguments>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>


### PR DESCRIPTION
Changed ITI.Bottle.Tests to launch NUnit as a start action in the csproj of the project.

This should enable everyone to launch the test without have to do the configuration manually.
*(Such a lazy bunch)*